### PR TITLE
feat(pattern-editor): add Pattern Editor component for cross-stitch p…

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -22,6 +22,10 @@
   --color-error: #ef4444;
 }
 
+button {
+  cursor: pointer;
+}
+
 html,
 body {
   @apply bg-white dark:bg-gray-900;

--- a/app/i18n/resources.ts
+++ b/app/i18n/resources.ts
@@ -138,6 +138,19 @@ export const resources = {
         },
       },
 
+      // --- Pattern Editor ---
+      patternEditor: {
+        title: 'Pattern Editor',
+        loading: 'Generating pattern…',
+        generationError: 'Failed to generate pattern. Please try again.',
+        zoom: 'Zoom',
+        colorLegend: 'Color Legend',
+        colorCount: '{{count}} colors',
+        dmcCode: 'DMC {{code}}',
+        stitchCount: '{{count}} st.',
+        dimensions: '{{width}} × {{height}} stitches',
+      },
+
       // --- PWA ---
       pwa: {
         installPrompt: 'Install App',
@@ -287,6 +300,19 @@ export const resources = {
           patternSize: 'Настройте финальные размеры схемы',
           maxColors: 'Ограничьте количество используемых цветов ниток',
         },
+      },
+
+      // --- Pattern Editor ---
+      patternEditor: {
+        title: 'Редактор схемы',
+        loading: 'Создание схемы…',
+        generationError: 'Не удалось создать схему. Попробуйте ещё раз.',
+        zoom: 'Масштаб',
+        colorLegend: 'Цветовая палитра',
+        colorCount: '{{count}} цветов',
+        dmcCode: 'DMC {{code}}',
+        stitchCount: '{{count}} кр.',
+        dimensions: '{{width}} × {{height}} крестиков',
       },
 
       // --- PWA ---

--- a/app/pages/patternEditor/components/ColorLegend.tsx
+++ b/app/pages/patternEditor/components/ColorLegend.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from 'react-i18next';
+import type { StitchColor } from '~/utils/patternGeneration';
+
+interface ColorLegendProps {
+  palette: StitchColor[];
+}
+
+function contrastColor(r: number, g: number, b: number): string {
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000' : '#fff';
+}
+
+const ColorLegend = ({ palette }: ColorLegendProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+        <h3 className="text-sm font-medium text-gray-900 dark:text-white">
+          {t('patternEditor.colorLegend')}
+        </h3>
+        <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+          {t('patternEditor.colorCount', { count: palette.length })}
+        </p>
+      </div>
+      <ul
+        className="divide-y divide-gray-100 overflow-y-auto dark:divide-gray-700"
+        style={{ maxHeight: '480px' }}
+      >
+        {palette.map(({ dmcColor, symbol, count }) => {
+          const { r, g, b } = dmcColor.rgb;
+          return (
+            <li
+              key={String(dmcColor.floss)}
+              className="flex items-center gap-3 px-4 py-2"
+            >
+              {/* Color swatch with symbol */}
+              <div
+                className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded border border-black/10 text-xs font-bold"
+                style={{
+                  backgroundColor: dmcColor.hex,
+                  color: contrastColor(r, g, b),
+                }}
+              >
+                {symbol}
+              </div>
+
+              {/* DMC info */}
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs font-medium text-gray-900 dark:text-white">
+                  {t('patternEditor.dmcCode', { code: dmcColor.floss })}
+                </p>
+                <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                  {dmcColor.label}
+                </p>
+              </div>
+
+              {/* Stitch count */}
+              <span className="flex-shrink-0 text-xs text-gray-400 dark:text-gray-500">
+                {t('patternEditor.stitchCount', { count })}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default ColorLegend;

--- a/app/pages/patternEditor/components/PatternGrid.tsx
+++ b/app/pages/patternEditor/components/PatternGrid.tsx
@@ -35,7 +35,7 @@ const PatternGrid = ({ pattern, cellSize }: PatternGridProps) => {
 
     for (let row = 0; row < height; row++) {
       for (let col = 0; col < width; col++) {
-        const { dmcColor, symbol } = palette[grid[row][col]];
+        const { dmcColor, symbol } = palette[grid[row * width + col]];
         const x = col * cellSize;
         const y = row * cellSize;
 

--- a/app/pages/patternEditor/components/PatternGrid.tsx
+++ b/app/pages/patternEditor/components/PatternGrid.tsx
@@ -1,0 +1,97 @@
+import { useRef } from 'react';
+import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
+import type { PatternResult } from '~/utils/patternGeneration';
+
+interface PatternGridProps {
+  pattern: PatternResult;
+  cellSize: number;
+}
+
+// Bold guide lines every N stitches (like graph paper)
+const GUIDE_INTERVAL = 10;
+
+const PatternGrid = ({ pattern, cellSize }: PatternGridProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useIsomorphicLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const { grid, palette, width, height } = pattern;
+
+    canvas.width = width * cellSize;
+    canvas.height = height * cellSize;
+
+    // Draw colored cells and symbols
+    const showSymbols = cellSize >= 8;
+    const fontSize = Math.floor(cellSize * 0.6);
+    if (showSymbols) {
+      ctx.font = `bold ${fontSize}px monospace`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+    }
+
+    for (let row = 0; row < height; row++) {
+      for (let col = 0; col < width; col++) {
+        const { dmcColor, symbol } = palette[grid[row][col]];
+        const x = col * cellSize;
+        const y = row * cellSize;
+
+        ctx.fillStyle = dmcColor.hex;
+        ctx.fillRect(x, y, cellSize, cellSize);
+
+        if (showSymbols) {
+          const { r, g, b } = dmcColor.rgb;
+          const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+          ctx.fillStyle =
+            luminance > 0.5 ? 'rgba(0,0,0,0.75)' : 'rgba(255,255,255,0.85)';
+          ctx.fillText(symbol, x + cellSize / 2, y + cellSize / 2);
+        }
+      }
+    }
+
+    // Fine grid lines
+    ctx.strokeStyle = 'rgba(0,0,0,0.15)';
+    ctx.lineWidth = 0.5;
+    for (let col = 0; col <= width; col++) {
+      if (col % GUIDE_INTERVAL === 0) continue;
+      ctx.beginPath();
+      ctx.moveTo(col * cellSize, 0);
+      ctx.lineTo(col * cellSize, height * cellSize);
+      ctx.stroke();
+    }
+    for (let row = 0; row <= height; row++) {
+      if (row % GUIDE_INTERVAL === 0) continue;
+      ctx.beginPath();
+      ctx.moveTo(0, row * cellSize);
+      ctx.lineTo(width * cellSize, row * cellSize);
+      ctx.stroke();
+    }
+
+    // Bold guide lines every GUIDE_INTERVAL stitches
+    ctx.strokeStyle = 'rgba(0,0,0,0.45)';
+    ctx.lineWidth = 1;
+    for (let col = 0; col <= width; col += GUIDE_INTERVAL) {
+      ctx.beginPath();
+      ctx.moveTo(col * cellSize, 0);
+      ctx.lineTo(col * cellSize, height * cellSize);
+      ctx.stroke();
+    }
+    for (let row = 0; row <= height; row += GUIDE_INTERVAL) {
+      ctx.beginPath();
+      ctx.moveTo(0, row * cellSize);
+      ctx.lineTo(width * cellSize, row * cellSize);
+      ctx.stroke();
+    }
+  }, [pattern, cellSize]);
+
+  return (
+    <div className="overflow-auto rounded-lg border border-gray-300 dark:border-gray-600">
+      <canvas ref={canvasRef} />
+    </div>
+  );
+};
+
+export default PatternGrid;

--- a/app/pages/patternEditor/patternEditor.tsx
+++ b/app/pages/patternEditor/patternEditor.tsx
@@ -62,7 +62,11 @@ export const PatternEditor = ({
       });
   }, [sourceFile, config, navigate, t]);
 
-  const handleBack = () => navigate(-1);
+  const handleBack = () =>
+    navigate('/config', {
+      replace: true,
+      state: { file: sourceFile, fileName },
+    });
 
   if (!sourceFile || !config) return null;
 

--- a/app/pages/patternEditor/patternEditor.tsx
+++ b/app/pages/patternEditor/patternEditor.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BiLoaderAlt } from 'react-icons/bi';
+import { useNavigate } from 'react-router';
+import NavigateBack from '~/components/NavigateBack';
+import type { ConfigData } from '~/pages/patternConfig/components/ConfigPanel';
+import type { PatternResult } from '~/utils/patternGeneration';
+import { generatePattern } from '~/utils/patternGeneration';
+import ColorLegend from './components/ColorLegend';
+import PatternGrid from './components/PatternGrid';
+
+interface PatternEditorProps {
+  file?: File;
+  fileName?: string;
+  config?: ConfigData;
+  originalFile?: File;
+}
+
+const CELL_SIZES = [4, 6, 8, 10, 12, 16, 20] as const;
+const DEFAULT_CELL_SIZE = 10;
+
+export const PatternEditor = ({
+  file,
+  fileName,
+  config,
+  originalFile,
+}: PatternEditorProps) => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [pattern, setPattern] = useState<PatternResult | null>(null);
+  const [isGenerating, setIsGenerating] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cellSize, setCellSize] = useState(DEFAULT_CELL_SIZE);
+
+  // Prefer the original full-resolution file for best quality
+  const sourceFile = originalFile ?? file;
+
+  useEffect(() => {
+    if (!sourceFile || !config) {
+      navigate('/', { replace: true });
+      return;
+    }
+
+    setIsGenerating(true);
+    setError(null);
+
+    generatePattern(
+      sourceFile,
+      config.patternWidthStitches,
+      config.patternHeightStitches,
+      config.maxColors
+    )
+      .then(result => {
+        setPattern(result);
+        setIsGenerating(false);
+      })
+      .catch(err => {
+        console.error('Pattern generation failed:', err);
+        setError(t('patternEditor.generationError'));
+        setIsGenerating(false);
+      });
+  }, [sourceFile, config, navigate, t]);
+
+  const handleBack = () => navigate(-1);
+
+  if (!sourceFile || !config) return null;
+
+  return (
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <NavigateBack handleBack={handleBack} />
+
+      <div className="container mx-auto px-4 pb-12">
+        {/* Header */}
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+              {t('patternEditor.title')}
+            </h1>
+            {fileName && (
+              <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+                {fileName}
+              </p>
+            )}
+          </div>
+
+          {/* Zoom controls */}
+          {pattern && (
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-gray-600 dark:text-gray-400">
+                {t('patternEditor.zoom')}
+              </span>
+              <div className="flex gap-1">
+                {CELL_SIZES.map(size => (
+                  <button
+                    key={size}
+                    onClick={() => setCellSize(size)}
+                    className={`rounded px-2 py-1 text-xs font-medium transition-colors ${
+                      cellSize === size
+                        ? 'bg-primary text-white'
+                        : 'bg-white text-gray-700 hover:bg-gray-100 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+                    }`}
+                  >
+                    {size}px
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Loading state */}
+        {isGenerating && (
+          <div className="flex flex-col items-center justify-center py-32">
+            <BiLoaderAlt className="h-10 w-10 animate-spin text-primary" />
+            <p className="mt-4 text-sm text-gray-600 dark:text-gray-400">
+              {t('patternEditor.loading')}
+            </p>
+          </div>
+        )}
+
+        {/* Error state */}
+        {error && !isGenerating && (
+          <div className="rounded-lg border border-red-200 bg-red-50 p-6 text-center dark:border-red-800 dark:bg-red-900/20">
+            <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+          </div>
+        )}
+
+        {/* Pattern + legend */}
+        {pattern && !isGenerating && (
+          <div className="grid gap-6 lg:grid-cols-[1fr_280px]">
+            {/* Grid */}
+            <div className="space-y-2">
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {t('patternEditor.dimensions', {
+                  width: pattern.width,
+                  height: pattern.height,
+                })}
+              </p>
+              <PatternGrid pattern={pattern} cellSize={cellSize} />
+            </div>
+
+            {/* Legend */}
+            <ColorLegend palette={pattern.palette} />
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};
+
+export default PatternEditor;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,6 +3,7 @@ import { type RouteConfig, index, route } from '@react-router/dev/routes';
 export default [
   index('routes/home.tsx'),
   route('config', 'routes/config.tsx'),
+  route('pattern-editor', 'routes/pattern-editor.tsx'),
   // Splat route for Chrome DevTools and other unmatched requests
   route('*', 'routes/$.tsx'),
 ] satisfies RouteConfig;

--- a/app/routes/pattern-editor.tsx
+++ b/app/routes/pattern-editor.tsx
@@ -1,0 +1,26 @@
+import { useLocation } from 'react-router';
+import { PatternEditor } from '../pages/patternEditor/patternEditor';
+
+export function meta() {
+  return [
+    { title: 'Pattern Editor - Cross Stitch Pattern Generator' },
+    {
+      name: 'description',
+      content: 'View and export your generated cross-stitch pattern',
+    },
+  ];
+}
+
+export default function PatternEditorRoute() {
+  const location = useLocation();
+  const { file, fileName, config, originalFile } = location.state || {};
+
+  return (
+    <PatternEditor
+      file={file}
+      fileName={fileName}
+      config={config}
+      originalFile={originalFile}
+    />
+  );
+}

--- a/app/types/pattern.ts
+++ b/app/types/pattern.ts
@@ -1,0 +1,82 @@
+import type { DMCColor } from './colors';
+
+export interface StitchColor {
+  dmcColor: DMCColor;
+  symbol: string;
+  count: number;
+}
+
+export interface PatternResult {
+  /** Flat row-major array: grid[row * width + col] = palette index */
+  grid: Uint16Array;
+  palette: StitchColor[];
+  width: number;
+  height: number;
+}
+
+export interface WorkerInput {
+  pixels: ArrayBuffer;
+  width: number;
+  height: number;
+  maxColors: number;
+}
+
+export interface WorkerOutput {
+  grid: ArrayBuffer;
+  palette: StitchColor[];
+  width: number;
+  height: number;
+}
+
+export const SYMBOLS = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+  'Z',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '+',
+  '/',
+  '@',
+  '#',
+  '$',
+  '%',
+  '&',
+  '*',
+  '=',
+  '~',
+  '<',
+  '>',
+  '!',
+  '?',
+  '^',
+];

--- a/app/utils/patternGeneration.ts
+++ b/app/utils/patternGeneration.ts
@@ -1,0 +1,195 @@
+import { colord, extend } from 'colord';
+import labPlugin from 'colord/plugins/lab';
+import type { DMCColor, RGBColor } from '~/types/colors';
+import { closestDMC } from './colorUtils';
+
+extend([labPlugin]);
+
+// Printable symbols assigned to palette colors (for print legibility)
+export const SYMBOLS = [
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+  'Z',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '+',
+  '/',
+  '@',
+  '#',
+  '$',
+  '%',
+  '&',
+  '*',
+  '=',
+  '~',
+  '<',
+  '>',
+  '!',
+  '?',
+  '^',
+];
+
+export interface StitchColor {
+  dmcColor: DMCColor;
+  symbol: string;
+  count: number;
+}
+
+export interface PatternResult {
+  /** Row-major 2D array of palette indices */
+  grid: Uint16Array[];
+  palette: StitchColor[];
+  width: number;
+  height: number;
+}
+
+/**
+ * Generates a cross-stitch pattern from an image file.
+ *
+ * Steps:
+ * 1. Render image to an offscreen canvas at pattern dimensions
+ * 2. Map every pixel to its closest DMC thread color
+ * 3. Keep the top `maxColors` by frequency; remap the rest to the nearest kept color
+ * 4. Build the final grid and palette
+ */
+export async function generatePattern(
+  imageFile: File,
+  width: number,
+  height: number,
+  maxColors: number
+): Promise<PatternResult> {
+  const img = await loadImage(imageFile);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context unavailable');
+
+  ctx.drawImage(img, 0, 0, width, height);
+  const { data } = ctx.getImageData(0, 0, width, height);
+
+  // --- Step 1: map every pixel to its closest DMC color ---
+  const pixelCount = width * height;
+  const pixelDMC: DMCColor[] = new Array(pixelCount);
+  for (let i = 0; i < pixelCount; i++) {
+    const base = i * 4;
+    const rgb: RGBColor = {
+      r: data[base],
+      g: data[base + 1],
+      b: data[base + 2],
+    };
+    pixelDMC[i] = closestDMC(rgb);
+  }
+
+  // --- Step 2: count frequencies ---
+  const freq = new Map<string, { color: DMCColor; count: number }>();
+  for (const color of pixelDMC) {
+    const key = String(color.floss);
+    const entry = freq.get(key);
+    if (entry) {
+      entry.count++;
+    } else {
+      freq.set(key, { color, count: 1 });
+    }
+  }
+
+  // --- Step 3: keep top `maxColors` ---
+  const sorted = [...freq.values()].sort((a, b) => b.count - a.count);
+  const kept = sorted.slice(0, maxColors);
+  const keptKeys = new Set(kept.map(c => String(c.color.floss)));
+
+  // Remap dropped colors to nearest kept color (by perceptual LAB distance)
+  const remapCache = new Map<string, DMCColor>();
+  const remap = (color: DMCColor): DMCColor => {
+    const key = String(color.floss);
+    if (keptKeys.has(key)) return color;
+    const cached = remapCache.get(key);
+    if (cached) return cached;
+
+    let best = kept[0].color;
+    let minDelta = Infinity;
+    for (const { color: keptColor } of kept) {
+      const delta = colord(color.rgb).delta(keptColor.rgb);
+      if (delta < minDelta) {
+        minDelta = delta;
+        best = keptColor;
+      }
+    }
+    remapCache.set(key, best);
+    return best;
+  };
+
+  // --- Step 4: build palette and grid ---
+  const palette: StitchColor[] = kept.map((item, i) => ({
+    dmcColor: item.color,
+    symbol: SYMBOLS[i % SYMBOLS.length],
+    count: 0,
+  }));
+
+  const paletteIndex = new Map<string, number>();
+  palette.forEach((item, i) =>
+    paletteIndex.set(String(item.dmcColor.floss), i)
+  );
+
+  const grid: Uint16Array[] = [];
+  let pixelIdx = 0;
+  for (let row = 0; row < height; row++) {
+    const gridRow = new Uint16Array(width);
+    for (let col = 0; col < width; col++) {
+      const mapped = remap(pixelDMC[pixelIdx++]);
+      const idx = paletteIndex.get(String(mapped.floss))!;
+      gridRow[col] = idx;
+      palette[idx].count++;
+    }
+    grid.push(gridRow);
+  }
+
+  return { grid, palette, width, height };
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = e => {
+      URL.revokeObjectURL(url);
+      reject(e);
+    };
+    img.src = url;
+  });
+}

--- a/app/utils/patternGeneration.ts
+++ b/app/utils/patternGeneration.ts
@@ -1,87 +1,12 @@
-import { colord, extend } from 'colord';
-import labPlugin from 'colord/plugins/lab';
-import type { DMCColor, RGBColor } from '~/types/colors';
-import { closestDMC } from './colorUtils';
+import type {
+  PatternResult,
+  WorkerInput,
+  WorkerOutput,
+} from '../types/pattern';
 
-extend([labPlugin]);
+export { SYMBOLS } from '../types/pattern';
+export type { PatternResult, StitchColor } from '../types/pattern';
 
-// Printable symbols assigned to palette colors (for print legibility)
-export const SYMBOLS = [
-  'A',
-  'B',
-  'C',
-  'D',
-  'E',
-  'F',
-  'G',
-  'H',
-  'I',
-  'J',
-  'K',
-  'L',
-  'M',
-  'N',
-  'O',
-  'P',
-  'Q',
-  'R',
-  'S',
-  'T',
-  'U',
-  'V',
-  'W',
-  'X',
-  'Y',
-  'Z',
-  '1',
-  '2',
-  '3',
-  '4',
-  '5',
-  '6',
-  '7',
-  '8',
-  '9',
-  '+',
-  '/',
-  '@',
-  '#',
-  '$',
-  '%',
-  '&',
-  '*',
-  '=',
-  '~',
-  '<',
-  '>',
-  '!',
-  '?',
-  '^',
-];
-
-export interface StitchColor {
-  dmcColor: DMCColor;
-  symbol: string;
-  count: number;
-}
-
-export interface PatternResult {
-  /** Row-major 2D array of palette indices */
-  grid: Uint16Array[];
-  palette: StitchColor[];
-  width: number;
-  height: number;
-}
-
-/**
- * Generates a cross-stitch pattern from an image file.
- *
- * Steps:
- * 1. Render image to an offscreen canvas at pattern dimensions
- * 2. Map every pixel to its closest DMC thread color
- * 3. Keep the top `maxColors` by frequency; remap the rest to the nearest kept color
- * 4. Build the final grid and palette
- */
 export async function generatePattern(
   imageFile: File,
   width: number,
@@ -89,93 +14,41 @@ export async function generatePattern(
   maxColors: number
 ): Promise<PatternResult> {
   const img = await loadImage(imageFile);
-
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas 2D context unavailable');
-
   ctx.drawImage(img, 0, 0, width, height);
-  const { data } = ctx.getImageData(0, 0, width, height);
 
-  // --- Step 1: map every pixel to its closest DMC color ---
-  const pixelCount = width * height;
-  const pixelDMC: DMCColor[] = new Array(pixelCount);
-  for (let i = 0; i < pixelCount; i++) {
-    const base = i * 4;
-    const rgb: RGBColor = {
-      r: data[base],
-      g: data[base + 1],
-      b: data[base + 2],
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const pixels = imageData.data.buffer.slice(0);
+
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL('../workers/patternGeneration.worker.ts', import.meta.url),
+      { type: 'module' }
+    );
+
+    worker.onmessage = (e: MessageEvent<WorkerOutput>) => {
+      worker.terminate();
+      const { grid: gridBuffer, palette, width: w, height: h } = e.data;
+      resolve({
+        grid: new Uint16Array(gridBuffer),
+        palette,
+        width: w,
+        height: h,
+      });
     };
-    pixelDMC[i] = closestDMC(rgb);
-  }
 
-  // --- Step 2: count frequencies ---
-  const freq = new Map<string, { color: DMCColor; count: number }>();
-  for (const color of pixelDMC) {
-    const key = String(color.floss);
-    const entry = freq.get(key);
-    if (entry) {
-      entry.count++;
-    } else {
-      freq.set(key, { color, count: 1 });
-    }
-  }
+    worker.onerror = err => {
+      worker.terminate();
+      reject(err);
+    };
 
-  // --- Step 3: keep top `maxColors` ---
-  const sorted = [...freq.values()].sort((a, b) => b.count - a.count);
-  const kept = sorted.slice(0, maxColors);
-  const keptKeys = new Set(kept.map(c => String(c.color.floss)));
-
-  // Remap dropped colors to nearest kept color (by perceptual LAB distance)
-  const remapCache = new Map<string, DMCColor>();
-  const remap = (color: DMCColor): DMCColor => {
-    const key = String(color.floss);
-    if (keptKeys.has(key)) return color;
-    const cached = remapCache.get(key);
-    if (cached) return cached;
-
-    let best = kept[0].color;
-    let minDelta = Infinity;
-    for (const { color: keptColor } of kept) {
-      const delta = colord(color.rgb).delta(keptColor.rgb);
-      if (delta < minDelta) {
-        minDelta = delta;
-        best = keptColor;
-      }
-    }
-    remapCache.set(key, best);
-    return best;
-  };
-
-  // --- Step 4: build palette and grid ---
-  const palette: StitchColor[] = kept.map((item, i) => ({
-    dmcColor: item.color,
-    symbol: SYMBOLS[i % SYMBOLS.length],
-    count: 0,
-  }));
-
-  const paletteIndex = new Map<string, number>();
-  palette.forEach((item, i) =>
-    paletteIndex.set(String(item.dmcColor.floss), i)
-  );
-
-  const grid: Uint16Array[] = [];
-  let pixelIdx = 0;
-  for (let row = 0; row < height; row++) {
-    const gridRow = new Uint16Array(width);
-    for (let col = 0; col < width; col++) {
-      const mapped = remap(pixelDMC[pixelIdx++]);
-      const idx = paletteIndex.get(String(mapped.floss))!;
-      gridRow[col] = idx;
-      palette[idx].count++;
-    }
-    grid.push(gridRow);
-  }
-
-  return { grid, palette, width, height };
+    const msg: WorkerInput = { pixels, width, height, maxColors };
+    worker.postMessage(msg, [pixels]);
+  });
 }
 
 function loadImage(file: File): Promise<HTMLImageElement> {

--- a/app/workers/patternGeneration.worker.ts
+++ b/app/workers/patternGeneration.worker.ts
@@ -1,0 +1,100 @@
+import { colord, extend } from 'colord';
+import labPlugin from 'colord/plugins/lab';
+import dmcPalette from '../assets/dmc_palette.json';
+import type { DMCColor, RGBColor } from '../types/colors';
+import type { WorkerInput, WorkerOutput } from '../types/pattern';
+import { SYMBOLS } from '../types/pattern';
+
+extend([labPlugin]);
+
+function closestDMC(rgb: RGBColor): DMCColor {
+  const lab = colord(rgb).toLab();
+  let best = dmcPalette[0];
+  let minDelta = Infinity;
+  for (const dmc of dmcPalette) {
+    const delta = colord(lab).delta(dmc.lab);
+    if (delta < minDelta) {
+      minDelta = delta;
+      best = dmc;
+    }
+  }
+  return best;
+}
+
+function compute(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+  maxColors: number
+): WorkerOutput {
+  const pixelCount = width * height;
+
+  const pixelDMC: DMCColor[] = new Array(pixelCount);
+  for (let i = 0; i < pixelCount; i++) {
+    const base = i * 4;
+    pixelDMC[i] = closestDMC({
+      r: data[base],
+      g: data[base + 1],
+      b: data[base + 2],
+    });
+  }
+
+  const freq = new Map<string, { color: DMCColor; count: number }>();
+  for (const color of pixelDMC) {
+    const key = String(color.floss);
+    const entry = freq.get(key);
+    if (entry) entry.count++;
+    else freq.set(key, { color, count: 1 });
+  }
+
+  const sorted = [...freq.values()].sort((a, b) => b.count - a.count);
+  const kept = sorted.slice(0, maxColors);
+  const keptKeys = new Set(kept.map(c => String(c.color.floss)));
+
+  const remapCache = new Map<string, DMCColor>();
+  function remap(color: DMCColor): DMCColor {
+    const key = String(color.floss);
+    if (keptKeys.has(key)) return color;
+    const cached = remapCache.get(key);
+    if (cached) return cached;
+    let best = kept[0].color;
+    let minDelta = Infinity;
+    for (const { color: k } of kept) {
+      const delta = colord(color.rgb).delta(k.rgb);
+      if (delta < minDelta) {
+        minDelta = delta;
+        best = k;
+      }
+    }
+    remapCache.set(key, best);
+    return best;
+  }
+
+  const palette = kept.map((item, i) => ({
+    dmcColor: item.color,
+    symbol: SYMBOLS[i % SYMBOLS.length],
+    count: 0,
+  }));
+
+  const paletteIndex = new Map<string, number>();
+  palette.forEach((item, i) =>
+    paletteIndex.set(String(item.dmcColor.floss), i)
+  );
+
+  const grid = new Uint16Array(pixelCount);
+  for (let i = 0; i < pixelCount; i++) {
+    const mapped = remap(pixelDMC[i]);
+    const idx = paletteIndex.get(String(mapped.floss))!;
+    grid[i] = idx;
+    palette[idx].count++;
+  }
+
+  return { grid: grid.buffer, palette, width, height };
+}
+
+self.onmessage = (e: MessageEvent<WorkerInput>) => {
+  const { pixels, width, height, maxColors } = e.data;
+  const data = new Uint8ClampedArray(pixels);
+  const result = compute(data, width, height, maxColors);
+  postMessage(result, { transfer: [result.grid] });
+};


### PR DESCRIPTION
…attern generation

- Introduced a new Pattern Editor route and component to facilitate the generation of cross-stitch patterns from image files.
- Implemented a grid display for the generated pattern and a color legend for DMC thread colors.
- Added internationalization support for the Pattern Editor, including English and Russian translations.
- Enhanced routing to include the new pattern editor functionality, improving user navigation and experience.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new end-to-end pattern generation flow using a Web Worker and canvas rendering; main risk is performance/memory/compatibility issues with large images and worker/message passing.
> 
> **Overview**
> Introduces a new **Pattern Editor** experience reachable via the new `pattern-editor` route, taking the configured image+settings from `/config` and generating a stitch pattern with loading/error states and zoom controls.
> 
> Implements worker-based pattern generation (`generatePattern` + `patternGeneration.worker.ts`) that maps pixels to nearest DMC colors, limits to `maxColors`, produces a `Uint16Array` grid plus palette counts/symbols, and renders the result as a canvas grid (`PatternGrid`) alongside a DMC color legend (`ColorLegend`).
> 
> Adds `patternEditor` i18n strings (EN/RU) and a small global CSS tweak to make `button` show a pointer cursor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77b3b1009a2e5a4d8d6b4ef05184c4d5f1165205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->